### PR TITLE
Validate comp codelists

### DIFF
--- a/pmd4/src/rdf-validator-suite.edn
+++ b/pmd4/src/rdf-validator-suite.edn
@@ -1,4 +1,7 @@
-{:pmd4 [{:source "swirrl/validations/pmd4/SELECT_BroaderObjectsMustBeAConcept.sparql"
+{:pmd4 [{:source "swirrl/validations/pmd4/SELECT_AllAttributesAndDimensionsMustHaveCodeList.sparql"
+	 :type :sparql
+	 :name "AllAttributesAndDimensionsMustHaveCodeList"}
+        {:source "swirrl/validations/pmd4/SELECT_BroaderObjectsMustBeAConcept.sparql"
 	 :type :sparql
 	 :name "BroaderObjectsMustBeAConcept"}
         {:source "swirrl/validations/pmd4/SELECT_ConceptExactlyOneLabel.sparql"

--- a/pmd4/src/rdf-validator-suite.edn
+++ b/pmd4/src/rdf-validator-suite.edn
@@ -1,139 +1,105 @@
 {:pmd4 [{:source "swirrl/validations/pmd4/SELECT_BroaderObjectsMustBeAConcept.sparql"
-					:type :sparql
-					:name "BroaderObjectsMustBeAConcept"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptExactlyOneLabel.sparql"
-					:type :sparql
-					:name "ConceptExactlyOneLabel"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptMaxOneComment.sparql"
-					:type :sparql
-					:name "ConceptMaxOneComment"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptMaxOneNotation.sparql"
-					:type :sparql
-					:name "ConceptMaxOneNotation"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptMinOneScheme.sparql"
-					:type :sparql
-					:name "ConceptMinOneScheme"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptSchemeExactlyOneLabel.sparql"
-					:type :sparql
-					:name "ConceptSchemeExactlyOneLabel"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptSchemeMustHaveCatalogEntry.sparql"
-					:type :sparql
-					:name "ConceptSchemeMustHaveCatalogEntry"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptSchemesMaxZeroConceptsAsMembers.sparql"
-					:type :sparql
-					:name "ConceptSchemesMaxZeroConceptsAsMembers"}
-{
-					:source "swirrl/validations/pmd4/SELECT_ConceptsMaxOfOneSortPriority.sparql"
-					:type :sparql
-					:name "ConceptsMaxOfOneSortPriority"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetContactPointIsIri.sparql"
-					:type :sparql
-					:name "DatasetContactPointIsIri"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetContentsIsCorrectType.sparql"
-					:type :sparql
-					:name "DatasetContentsIsCorrectType"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneContents.sparql"
-					:type :sparql
-					:name "DatasetExactlyOneContents"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneGraph.sparql"
-					:type :sparql
-					:name "DatasetExactlyOneGraph"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneIssuedDate.sparql"
-					:type :sparql
-					:name "DatasetExactlyOneIssuedDate"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneLabel.sparql"
-					:type :sparql
-					:name "DatasetExactlyOneLabel"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneModifiedDate.sparql"
-					:type :sparql
-					:name "DatasetExactlyOneModifiedDate"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetGraphIsIri.sparql"
-					:type :sparql
-					:name "DatasetGraphIsIri"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneContactPoint.sparql"
-					:type :sparql
-					:name "DatasetMaxOneContactPoint"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneContributor.sparql"
-					:type :sparql
-					:name "DatasetMaxOneContributor"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneCreator.sparql"
-					:type :sparql
-					:name "DatasetMaxOneCreator"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneLicense.sparql"
-					:type :sparql
-					:name "DatasetMaxOneLicense"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneMarkdownDesc.sparql"
-					:type :sparql
-					:name "DatasetMaxOneMarkdownDesc"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DatasetMaxOnePublisher.sparql"
-					:type :sparql
-					:name "DatasetMaxOnePublisher"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DimensionsExactlyOneLabel.sparql"
-					:type :sparql
-					:name "DimensionsExactlyOneLabel"}
-{
-					:source "swirrl/validations/pmd4/SELECT_DimensionsMustHaveConceptsInCodeList.sparql"
-					:type :sparql
-					:name "DimensionsMustHaveConceptsInCodeList"}
-{
-					:source "swirrl/validations/pmd4/SELECT_NarrowerObjectsMustBeAConcept.sparql"
-					:type :sparql
-					:name "NarrowerObjectsMustBeAConcept"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneIssuedDate.sparql"
-					:type :sparql
-					:name "RecordExactlyOneIssuedDate"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneLabel.sparql"
-					:type :sparql
-					:name "RecordExactlyOneLabel"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneMetadataGraph.sparql"
-					:type :sparql
-					:name "RecordExactlyOneMetadataGraph"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneModifiedDate.sparql"
-					:type :sparql
-					:name "RecordExactlyOneModifiedDate"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordExactlyOnePrimaryTopic.sparql"
-					:type :sparql
-					:name "RecordExactlyOnePrimaryTopic"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordMetadataGraphIsIri.sparql"
-					:type :sparql
-					:name "RecordMetadataGraphIsIri"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordPrimaryTopicIsDataset.sparql"
-					:type :sparql
-					:name "RecordPrimaryTopicIsDataset"}
-{
-					:source "swirrl/validations/pmd4/SELECT_RecordsMustBeInACatalog.sparql"
-					:type :sparql
-					:name "RecordsMustBeInACatalog"}
-{
-					:source "swirrl/validations/pmd4/SELECT_TopConceptOfObjectMustBeAConceptScheme.sparql"
-					:type :sparql
-					:name "TopConceptOfObjectMustBeAConceptScheme"}]}
+	 :type :sparql
+	 :name "BroaderObjectsMustBeAConcept"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptExactlyOneLabel.sparql"
+	 :type :sparql
+	 :name "ConceptExactlyOneLabel"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptMaxOneComment.sparql"
+	 :type :sparql
+	 :name "ConceptMaxOneComment"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptMaxOneNotation.sparql"
+	 :type :sparql
+	 :name "ConceptMaxOneNotation"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptMinOneScheme.sparql"
+	 :type :sparql
+	 :name "ConceptMinOneScheme"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptSchemeExactlyOneLabel.sparql"
+	 :type :sparql
+	 :name "ConceptSchemeExactlyOneLabel"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptSchemeMustHaveCatalogEntry.sparql"
+	 :type :sparql
+	 :name "ConceptSchemeMustHaveCatalogEntry"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptSchemesMaxZeroConceptsAsMembers.sparql"
+	 :type :sparql
+	 :name "ConceptSchemesMaxZeroConceptsAsMembers"}
+        {:source "swirrl/validations/pmd4/SELECT_ConceptsMaxOfOneSortPriority.sparql"
+	 :type :sparql
+	 :name "ConceptsMaxOfOneSortPriority"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetContactPointIsIri.sparql"
+	 :type :sparql
+	 :name "DatasetContactPointIsIri"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetContentsIsCorrectType.sparql"
+	 :type :sparql
+	 :name "DatasetContentsIsCorrectType"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneContents.sparql"
+	 :type :sparql
+	 :name "DatasetExactlyOneContents"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneGraph.sparql"
+	 :type :sparql
+	 :name "DatasetExactlyOneGraph"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneIssuedDate.sparql"
+	 :type :sparql
+	 :name "DatasetExactlyOneIssuedDate"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneLabel.sparql"
+	 :type :sparql
+	 :name "DatasetExactlyOneLabel"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetExactlyOneModifiedDate.sparql"
+	 :type :sparql
+	 :name "DatasetExactlyOneModifiedDate"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetGraphIsIri.sparql"
+	 :type :sparql
+	 :name "DatasetGraphIsIri"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneContactPoint.sparql"
+	 :type :sparql
+	 :name "DatasetMaxOneContactPoint"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneContributor.sparql"
+	 :type :sparql
+	 :name "DatasetMaxOneContributor"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneCreator.sparql"
+	 :type :sparql
+	 :name "DatasetMaxOneCreator"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneLicense.sparql"
+	 :type :sparql
+	 :name "DatasetMaxOneLicense"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetMaxOneMarkdownDesc.sparql"
+	 :type :sparql
+	 :name "DatasetMaxOneMarkdownDesc"}
+        {:source "swirrl/validations/pmd4/SELECT_DatasetMaxOnePublisher.sparql"
+	 :type :sparql
+	 :name "DatasetMaxOnePublisher"}
+        {:source "swirrl/validations/pmd4/SELECT_DimensionsExactlyOneLabel.sparql"
+	 :type :sparql
+	 :name "DimensionsExactlyOneLabel"}
+        {:source "swirrl/validations/pmd4/SELECT_DimensionsMustHaveConceptsInCodeList.sparql"
+	 :type :sparql
+	 :name "DimensionsMustHaveConceptsInCodeList"}
+        {:source "swirrl/validations/pmd4/SELECT_NarrowerObjectsMustBeAConcept.sparql"
+	 :type :sparql
+	 :name "NarrowerObjectsMustBeAConcept"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneIssuedDate.sparql"
+	 :type :sparql
+	 :name "RecordExactlyOneIssuedDate"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneLabel.sparql"
+	 :type :sparql
+	 :name "RecordExactlyOneLabel"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneMetadataGraph.sparql"
+	 :type :sparql
+	 :name "RecordExactlyOneMetadataGraph"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordExactlyOneModifiedDate.sparql"
+	 :type :sparql
+	 :name "RecordExactlyOneModifiedDate"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordExactlyOnePrimaryTopic.sparql"
+	 :type :sparql
+	 :name "RecordExactlyOnePrimaryTopic"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordMetadataGraphIsIri.sparql"
+	 :type :sparql
+	 :name "RecordMetadataGraphIsIri"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordPrimaryTopicIsDataset.sparql"
+	 :type :sparql
+	 :name "RecordPrimaryTopicIsDataset"}
+        {:source "swirrl/validations/pmd4/SELECT_RecordsMustBeInACatalog.sparql"
+	 :type :sparql
+	 :name "RecordsMustBeInACatalog"}
+        {:source "swirrl/validations/pmd4/SELECT_TopConceptOfObjectMustBeAConceptScheme.sparql"
+	 :type :sparql
+	 :name "TopConceptOfObjectMustBeAConceptScheme"}]}

--- a/pmd4/src/swirrl/validations/pmd4/SELECT_AllAttributesAndDimensionsMustHaveCodeList.sparql
+++ b/pmd4/src/swirrl/validations/pmd4/SELECT_AllAttributesAndDimensionsMustHaveCodeList.sparql
@@ -1,0 +1,30 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+PREFIX qb: <http://purl.org/linked-data/cube#>
+
+SELECT REDUCED ?comp_prop WHERE {
+  VALUES ?comp_kind {
+      qb:attribute
+      qb:dimension
+    }
+  ?dsd a qb:DataStructureDefinition .
+    # ok if dsd has component with qb:measure
+    ?dsd qb:component [?comp_kind ?comp_prop] .
+
+  FILTER NOT EXISTS {
+    ?comp_prop qb:codeList ?cs .
+  }
+}
+# This validation validates an extra PMD constraint that attributes
+# and dimensions used in a dataset should contain at least one
+# qb:codeList triple on the component property itself that identifies
+# the code lists that hold metadata on the component values themselves.
+#
+# In particular we make use of this in PMD to join labels onto
+# component values, when generating dataset downloads etc, where we
+# need to know the component values ahead of time (to avoid having to
+# join in queries that are repeated many times).
+#
+# Not including these links will result in downloads that contain
+# URI's rather than labels.


### PR DESCRIPTION
This validation validates an extra PMD constraint that attributes and dimensions used in a dataset should contain at least one `qb:codeList` triple on the component property itself that identifies the code lists that hold metadata on the component values themselves.

In particular we make use of this in PMD to join labels onto component values, when generating dataset downloads etc, where we need to know the component values ahead of time (to avoid having to join in queries that are repeated many times).

Not including these links will result in downloads that contain URI's rather than labels.