### PR TITLE
Add validation to confirm dataset graph contains contents

### DIFF
--- a/pmd4/src/rdf-validator-suite.edn
+++ b/pmd4/src/rdf-validator-suite.edn
@@ -62,6 +62,10 @@
 					:type :sparql
 					:name "DatasetExactlyOneModifiedDate"}
 {
+					:source "swirrl/validations/pmd4/SELECT_DatasetGraphContainsContents.sparql"
+					:type :sparql
+					:name "DatasetGraphContainsContents"}
+{
 					:source "swirrl/validations/pmd4/SELECT_DatasetGraphIsIri.sparql"
 					:type :sparql
 					:name "DatasetGraphIsIri"}

--- a/pmd4/src/swirrl/validations/pmd4/SELECT_DatasetGraphContainsContents.sparql
+++ b/pmd4/src/swirrl/validations/pmd4/SELECT_DatasetGraphContainsContents.sparql
@@ -1,0 +1,21 @@
+PREFIX qb:      <http://purl.org/linked-data/cube#>
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+PREFIX ui:      <http://www.w3.org/ns/ui#>
+PREFIX dcat:    <http://www.w3.org/ns/dcat#>
+PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
+PREFIX pmdcat:  <http://publishmydata.com/pmdcat#> 
+
+SELECT ?dataset ?g {
+    ?dataset a pmdcat:Dataset;
+      pmdcat:graph ?g;
+      pmdcat:datasetContents ?s;
+      .
+
+    FILTER NOT EXISTS {
+        GRAPH ?g {
+            ?s ?p ?o .
+        }
+    }
+
+    FILTER(sameTerm(?s, ?g))
+}

--- a/pmd4/src/swirrl/validations/pmd4/SELECT_DatasetGraphContainsContents.sparql
+++ b/pmd4/src/swirrl/validations/pmd4/SELECT_DatasetGraphContainsContents.sparql
@@ -1,21 +1,21 @@
-PREFIX qb:      <http://purl.org/linked-data/cube#>
-PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
-PREFIX ui:      <http://www.w3.org/ns/ui#>
-PREFIX dcat:    <http://www.w3.org/ns/dcat#>
-PREFIX foaf:    <http://xmlns.com/foaf/0.1/>
 PREFIX pmdcat:  <http://publishmydata.com/pmdcat#> 
 
-SELECT ?dataset ?g {
-    ?dataset a pmdcat:Dataset;
-      pmdcat:graph ?g;
-      pmdcat:datasetContents ?s;
-      .
+# pmdcat:datasetContents should either be in one of the pmdcat:graphs or the same thing
 
-    FILTER NOT EXISTS {
-        GRAPH ?g {
-            ?s ?p ?o .
-        }
+SELECT ?dataset ?contents {
+  ?dataset a pmdcat:Dataset;
+    pmdcat:datasetContents ?contents;
+    .
+
+  FILTER NOT EXISTS {
+    ?dataset pmdcat:graph ?graph .
+
+    GRAPH ?graph {
+      ?contents ?p ?o .
     }
+  }
 
-    FILTER(sameTerm(?s, ?g))
+  MINUS {
+    ?dataset pmdcat:graph ?contents
+  }
 }


### PR DESCRIPTION
Following [problems caused by a mistaken `pmdcat:graph` URI](https://onswebsite.slack.com/archives/CNA5LRUUT/p1611246787002600), this PR introduces a validation to ensure that the `pmdcat:datasetContents` is either in the `pmdcat:graph` or the same thing.

This validation finds an erroneous dataset on COGS staging (today) which is [apparently](https://swirrl.slack.com/archives/CDL3C7PGU/p1611319746046100) a workaround for a bug in Stardog rules. @RickMoynihan reckons it should be safe to remove the associated resources now.