### PR TITLE
Provide out of the box configuration to run these validations with the rdf-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,45 +7,24 @@ used against RDF data using the [RDF Validator](https://github.com/Swirrl/rdf-va
 - **pmd4** - as set of validations to check data relating to the catalog structure and other data expectations for PMD4 to function as expected
 - **qb** - a verbatim copy of the IC validations from the [RDF Data Cube specification](https://www.w3.org/TR/vocab-data-cube/#h3_wf-rules).
 
-## Quick Start:
+## Pre-requisities
 
-1. Install clojure cli tools using `brew install clojure/tools/clojure` (see [clojure cli docs](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools) for other installations)
-2. Create a new file named `deps.edn` (location is unimportant) with the following contents:
+1. Clone this github repo
+2. Install clojure cli tools using `brew install clojure/tools/clojure` (see [clojure cli docs](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools) for other installations)
 
-```clojure
-{:deps {;; NOTE each dep here is a validation suite
-        swirrl/validations.pmdqb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
-                                  :sha "ea669ddb996ba56a7af0dbf5a196c24b08324632"
-                                  :deps/manifest :deps
-                                  :deps/root "pmd-qb"}
-        swirrl/validations.pmd4 {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
-                                  :sha "ea669ddb996ba56a7af0dbf5a196c24b08324632"
-                                  :deps/manifest :deps
-                                  :deps/root "pmd4"}
-        ;;; Exclude any suites you don't want by commenting them out
-        ;;; or removing them.
-        
-        ;;swirrl/validations.qb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
-        ;;                       :sha "ea669ddb996ba56a7af0dbf5a196c24b08324632"
-        ;;                       :deps/manifest :deps
-        ;;                       :deps/root "qb"}                                  
-        }
- :aliases {:rdf-validator {:extra-deps { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
-                                                               :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
-                           :main-opts ["-m" "rdf-validator.core"]}
-           :local/validations {:classpath-overrides {swirrl/validations.pmdqb "/path/to/local/repo/pmd-rdf-validations/pmd-qb"
-                                                     swirrl/validations.pmd4 "/path/to/local/repo/pmd-rdf-validations/pmd4"}}
-                     }
- }
-```
+## Usage
 
-3. Navigate to the directory containing your newly created `deps.edn` file in the command line and run `clojure -A:rdf-validator --endpoint http://{server}:{port}/your-db-name/query` 
+Run `clojure -M:pmd4:validate -e http://my/sparql/endpoint`
+
+Inspecting this projects `deps.edn` will show that we define the aliases `:pmd4` (for the pmd4 suite), `:pmd-qb` (for the pmd-qb) whilst `:validate` pulls in the swirrl validation tool.
+
+Hence to also run `:pmd-qb` you would simply run `clojure -M:pmd4:pmd-qb:validate -e http://my/sparql/endpoint`
 
 ## How this works
 
-The above `deps.edn` configuration file declaratively specifies dependencies on two suites of SPARQL query validations.  These two suites happen to located at different paths within the same git repository, though they could easily be in separate repositories.  It additionally then specifies a dependency on the [RDF Validator](https://github.com/Swirrl/rdf-validator) itself under the `:rdf-validator` alias.
+The above `deps.edn` configuration file declaratively specifies dependencies on two suites of SPARQL query validations.  These two suites happen to located at different paths within the same git repository, though they could easily be in separate repositories.  It additionally then specifies a dependency on the [RDF Validator](https://github.com/Swirrl/rdf-validator) itself under the `:validate` alias.
 
-Running the command `clojure -A:rdf-validator <args>` will then automatically cause the dependencies to be fetched, cached for future use and put on the JVMs classpath before finally executing the [RDF Validator](https://github.com/Swirrl/rdf-validator) application with the specified suites.
+Running the command `clojure -M:validate <args>` will then automatically cause the dependencies to be fetched, cached for future use and put on the JVMs classpath before finally executing the [RDF Validator](https://github.com/Swirrl/rdf-validator) application with the specified suites.
 
 As the [RDF Validator](https://github.com/Swirrl/rdf-validator) supports finding and loading validation suites from the java classpath the dependent suites will then be executed.  The validator defines a simple manifest for discovering and executing suites specified in this manner.
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,14 @@
+{:aliases {:pmd4 {:extra-deps {swirrl/validations.pmd4 {:local/root "pmd4"}}}
+           :pmd-qb {:extra-deps {swirrl/validations.pmd-qb {:local/root "pmd-qb"}}}
+
+           :validate {:extra-deps { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
+                                                          :sha "5ecc5fa5c696cfa8ac5bb99c250e5b0c9b083f85"
+                                                          }
+                                   ;; Import log4j2 as the logging backend
+                                   org.apache.logging.log4j/log4j-api {:mvn/version "2.11.1"}
+                                   org.apache.logging.log4j/log4j-core {:mvn/version "2.11.1"}
+                                   org.apache.logging.log4j/log4j-slf4j-impl {:mvn/version "2.11.1"}
+
+                                   }
+                      :extra-paths ["."] ;; for log4j2.xml
+                      :main-opts ["-m" "rdf-validator.core"]}}}

--- a/docs/customising.md
+++ b/docs/customising.md
@@ -1,0 +1,49 @@
+# Customising validation suites
+
+You can use `deps.edn` to depend upon validation suites managed as
+library dependencies. These dependencies can be either created as
+maven artifacts or even easier, point to git commits in git
+repositories.
+
+e.g. create a new file named `deps.edn` (location is unimportant) with the following contents:
+
+```clojure
+{:deps {;; NOTE each dep here is a validation suite
+        swirrl/validations.pmdqb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
+                                  :sha "ea669ddb996ba56a7af0dbf5a196c24b08324632"
+                                  :deps/manifest :deps
+                                  :deps/root "pmd-qb"}
+        swirrl/validations.pmd4 {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
+                                  :sha "ea669ddb996ba56a7af0dbf5a196c24b08324632"
+                                  :deps/manifest :deps
+                                  :deps/root "pmd4"}
+        ;;; Exclude any suites you don't want by commenting them out
+        ;;; or removing them.
+
+        ;;swirrl/validations.qb {:git/url "git@github.com:Swirrl/pmd-rdf-validations.git"
+        ;;                       :sha "ea669ddb996ba56a7af0dbf5a196c24b08324632"
+        ;;                       :deps/manifest :deps
+        ;;                       :deps/root "qb"}
+        }
+ :aliases {:rdf-validator {:extra-deps { swirrl/rdf-validator {:git/url "https://github.com/Swirrl/rdf-validator.git"
+                                                               :sha "fd848fabc5718f876f99ee4ee5a3f89ea8529571"}}
+                           :main-opts ["-m" "rdf-validator.core"]}
+           :local/validations {:classpath-overrides {swirrl/validations.pmdqb "/path/to/local/repo/pmd-rdf-validations/pmd-qb"
+                                                     swirrl/validations.pmd4 "/path/to/local/repo/pmd-rdf-validations/pmd4"}}
+                     }
+ }
+```
+
+3. Navigate to the directory containing your newly created `deps.edn` file in the command line and run `clojure -M:rdf-validator --endpoint http://{server}:{port}/your-db-name/query`
+
+## How this works
+
+The above `deps.edn` configuration file declaratively specifies dependencies on two suites of SPARQL query validations.  These two suites happen to located at different paths within the same git repository, though they could easily be in separate repositories.  It additionally then specifies a dependency on the [RDF Validator](https://github.com/Swirrl/rdf-validator) itself under the `:rdf-validator` alias.
+
+Running the command `clojure -M:rdf-validator <args>` will then automatically cause the dependencies to be fetched, cached for future use and put on the JVMs classpath before finally executing the [RDF Validator](https://github.com/Swirrl/rdf-validator) application with the specified suites.
+
+As the [RDF Validator](https://github.com/Swirrl/rdf-validator) supports finding and loading validation suites from the java classpath the dependent suites will then be executed.  The validator defines a simple manifest for discovering and executing suites specified in this manner.
+
+## Trouble shooting
+
+- Make sure that the `:sha` values in your `deps.edn` match the latest commit SHAs for this [pmd-rdf-validations repo](https://github.com/Swirrl/pmd-rdf-validations/commits/master) and the [rdf-validator repo](https://github.com/Swirrl/rdf-validator/commits/master) respectively.

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Watch file for changes every 10 seconds -->
+<Configuration status="info">
+    <Appenders>
+        <Console name="console" target="SYSTEM_OUT">
+            <PatternLayout pattern="[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info" additivity="false">
+          <appender-ref ref="console" level="warn"/> <!-- only log warnings and worse to console -->
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
This PR changes so the project so if you clone this repo you get an out of the box configuration that can run the rdf-validator against an arbitrary endpoint with a single command.

e.g. to run against ons data:

`clojure -M:pmd4:validate -e https://staging.gss-data.org.uk/sparql`