### PR TITLE
Add validation for hierarchical schemes without skos:hasTopConcept

### DIFF
--- a/pmd4/src/rdf-validator-suite.edn
+++ b/pmd4/src/rdf-validator-suite.edn
@@ -133,7 +133,11 @@
 	 :source "swirrl/validations/pmd4/SELECT_RecordsMustBeInACatalog.sparql"
 	 :type :sparql
 	 :name "RecordsMustBeInACatalog"}
-        {
-	 :source "swirrl/validations/pmd4/SELECT_TopConceptOfObjectMustBeAConceptScheme.sparql"
+        {:source "swirrl/validations/pmd4/SELECT_TopConceptOfObjectMustBeAConceptScheme.sparql"
 	 :type :sparql
-	 :name "TopConceptOfObjectMustBeAConceptScheme"}]}
+	 :name "TopConceptOfObjectMustBeAConceptScheme"}
+        {:source "swirrl/validations/pmd4/hierarchical-scheme.sparql"
+	 :type :sparql
+	 :name "hierarchical-scheme"
+         :description "Concept Schemes with a skos:narrower hierarchy must define at least one skos:hasTopConcept"}
+        ]}

--- a/pmd4/src/swirrl/validations/pmd4/hierarchical-scheme.sparql
+++ b/pmd4/src/swirrl/validations/pmd4/hierarchical-scheme.sparql
@@ -1,0 +1,10 @@
+PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?scheme {
+  ?concept skos:inScheme ?scheme ;
+           skos:narrower ?narrower .
+
+  FILTER NOT EXISTS {
+    ?scheme skos:hasTopConcept ?top_concept .
+  }
+}


### PR DESCRIPTION
Currently fails on cogs with:

```
36 /Users/rick/repos/pmd-rdf-validations/pmd4/src/swirrl/validations/pmd4/hierarchical-scheme.sparql: FAILED

|                                  :scheme |
|------------------------------------------|
| <http://data.europa.eu/nuts/scheme/2010> |
| <http://data.europa.eu/nuts/scheme/2016> |
| <http://data.europa.eu/nuts/scheme/2013> |
```